### PR TITLE
Feat: support wasm on prove/verify funcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,6 @@ version = "0.1.0"
 dependencies = [
  "fibonacci-circuit",
  "halo2_proofs",
- "halo2curves 0.3.3",
  "plonkish_backend",
 ]
 
@@ -678,7 +677,6 @@ version = "0.1.0"
 dependencies = [
  "fibonacci-circuit",
  "halo2_proofs",
- "halo2curves 0.3.3",
  "plonkish_backend",
 ]
 
@@ -940,7 +938,6 @@ dependencies = [
  "bincode",
  "fibonacci-circuit",
  "halo2_proofs",
- "halo2curves 0.3.3",
  "plonkish_backend",
  "rand",
  "serde",
@@ -949,7 +946,7 @@ dependencies = [
 [[package]]
 name = "plonkish_backend"
 version = "0.1.0"
-source = "git+https://github.com/sifnoc/plonkish?branch=setup_custom#3e8d41907041a3b9e1b9bd1d22c03bbc054e740d"
+source = "git+https://github.com/sifnoc/plonkish?branch=setup_custom#4f42eeb3ff0666c74168d5b375cd789b46998e1b"
 dependencies = [
  "bincode",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "halo2_proofs",
- "halo2curves 0.3.3",
  "itertools 0.13.0",
  "once_cell",
  "plonkish_backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ resolver = "2"
 [workspace.dependencies]
 halo2_proofs = { git = "https://github.com/han0110/halo2.git", branch = "feature/for-benchmark" }
 plonkish_backend = { git = "https://github.com/sifnoc/plonkish", branch = "setup_custom", features = ["frontend-halo2", "benchmark"] }
-halo2curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.3" }
 bincode = "1.3.3"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Each implementation requires a SRS file, but Plonk, HyperPlonk, and Gemini use d
 For the Plonk backend, pre-generated SRS files are available for download [here - halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs?tab=readme-ov-file#download-the-converted-srs). Once you've downloaded the appropriate SRS file, you can use the following command to generate the proving and verifying keys:
 
 ```bash
-cargo run --release --bin gen-keys perpetual-powers-of-tau-raw-3
+cargo run --release --bin gen-plonk-keys perpetual-powers-of-tau-raw-3
 ```
 
 This will generate proving and verifying keys for the Fibonacci circuit using the Plonk implementation.
@@ -39,7 +39,7 @@ For HyperPlonk, the SRS file must be generated using the [hyperplonk_srs_generat
 Once you have the SRS file, you can then generate the proving and verifying keys:
 
 ```bash
-cargo run --release --bin gen-keys hyperplonk-srs-4
+cargo run --release --bin gen-hyperplonk-keys hyperplonk-srs-4
 ```
 
 ### 3. Gemini
@@ -48,6 +48,6 @@ For Gemini, the SRS file is generated using the [unihyperplonk_srs_generator](ht
 Next, generate the proving and verifying keys for Gemini:
 
 ```bash
-cargo run --release --bin gen-keys unihyperplonk-srs-4
+cargo run --release --bin gen-gemini-keys unihyperplonk-srs-4
 ```
 

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -10,7 +10,6 @@ default = ["frontend-halo2"]
 frontend-halo2 = ["dep:halo2_proofs"]
 
 [dependencies]
-halo2curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.3" }
 plotters = {version = "0.3.6", optional = true}
 serde = { version = "1.0.204", features = ["derive"] }
 bincode = { workspace = true }

--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -3,10 +3,10 @@ use std::{collections::HashMap, io::Cursor, marker::PhantomData};
 
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, SimpleFloorPlanner},
+    halo2curves::ff::Field,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance, Selector},
     poly::Rotation,
 };
-use halo2curves::ff::Field;
 use plonkish_backend::{
     backend::PlonkishBackend,
     frontend::halo2::{CircuitExt, Halo2Circuit},
@@ -413,7 +413,8 @@ pub mod test_utils {
         )
     }
 
-    pub fn helper_functions_test<PC>() where
+    pub fn helper_functions_test<PC>()
+    where
         PC: PlonkishComponents,
         ProofTranscript: TranscriptWrite<CommitmentChunk<Fr, PC::Pcs>, Fr>
             + TranscriptRead<CommitmentChunk<Fr, PC::Pcs>, Fr>,

--- a/circuit/src/io.rs
+++ b/circuit/src/io.rs
@@ -1,7 +1,7 @@
 use std::{
     error::Error,
     fs::File,
-    io::{Read, Write},
+    io::{BufReader, Read, Write},
     path::Path,
 };
 
@@ -13,7 +13,13 @@ use crate::PlonkishComponents;
 /// Read SRS from file.
 pub fn read_srs_path<PC: PlonkishComponents>(path: &Path) -> PC::Param {
     let filename = path.as_os_str().to_str().unwrap();
-    PC::ProvingBackend::setup_custom(filename).unwrap()
+    let mut reader = File::open(filename).unwrap();
+    PC::ProvingBackend::setup_custom(&mut reader).unwrap()
+}
+
+pub fn read_srs_bytes<PC: PlonkishComponents>(bytes: &[u8]) -> PC::Param {
+    let mut reader = BufReader::new(bytes);
+    PC::ProvingBackend::setup_custom(&mut reader).unwrap()
 }
 
 // This method only for prover/verifier params
@@ -27,6 +33,7 @@ pub fn save_to_file<P: AsRef<Path>, T: Serialize>(
     Ok(())
 }
 
+// Read proving/verifying key from file
 pub fn load_from_file<P: AsRef<Path> + ?Sized, T: for<'de> Deserialize<'de>>(
     path: &P,
 ) -> Result<T, Box<dyn Error>> {
@@ -37,12 +44,8 @@ pub fn load_from_file<P: AsRef<Path> + ?Sized, T: for<'de> Deserialize<'de>>(
     Ok(deserialized_data)
 }
 
-/// Read a proving key from the file.
-pub fn read_pk<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
-    load_from_file::<_, T>(path).unwrap()
-}
-
-/// Read a verification key from the file.
-pub fn read_vk<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
-    load_from_file::<_, T>(path).unwrap()
+// Read proving/verifying key from bytes
+pub fn load_from_bytes<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, Box<dyn Error>> {
+    let deserialized_data = bincode::deserialize(&bytes)?;
+    Ok(deserialized_data)
 }

--- a/circuit/src/serialisation.rs
+++ b/circuit/src/serialisation.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::FibonacciError;
-use halo2_proofs::halo2curves::ff::PrimeField;
-use halo2curves::bn256::Fr;
+use halo2_proofs::halo2curves::{bn256::Fr, ff::PrimeField};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/gemini/Cargo.toml
+++ b/gemini/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "gen-keys"
+name = "gen-gemini-keys"
 path = "src/bin/gen_gemini_keys.rs"
 
 [dependencies]
 fibonacci-circuit = { path = "../circuit" }
 halo2_proofs = { workspace = true }
 plonkish_backend = { workspace = true }
-halo2curves = { workspace = true }

--- a/gemini/src/lib.rs
+++ b/gemini/src/lib.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, error::Error};
 use fibonacci_circuit::{
     prove as _prove, verify as _verify, GenerateProofResult, PlonkishComponents,
 };
-use halo2curves::bn256::{Bn256, Fr};
+use halo2_proofs::halo2curves::bn256::{Bn256, Fr};
 use plonkish_backend::{
     backend::hyperplonk::{HyperPlonk, HyperPlonkProverParam, HyperPlonkVerifierParam},
     pcs::{
@@ -22,6 +22,7 @@ impl PlonkishComponents for GeminiScheme {
     type ProvingBackend = HyperPlonk<Self::Pcs>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn prove(
     srs_key_path: &str,
     proving_key_path: &str,
@@ -30,6 +31,16 @@ pub fn prove(
     _prove::<GeminiScheme>(srs_key_path, proving_key_path, input)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn prove(
+    srs_key: &[u8],
+    proving_key: &[u8],
+    input: HashMap<String, Vec<String>>,
+) -> Result<GenerateProofResult, Box<dyn Error>> {
+    _prove::<GeminiScheme>(srs_key, proving_key, input)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub fn verify(
     srs_key_path: &str,
     verifying_key_path: &str,
@@ -39,12 +50,23 @@ pub fn verify(
     _verify::<GeminiScheme>(srs_key_path, verifying_key_path, proof, public_inputs)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn verify(
+    srs_key: &[u8],
+    verifying_key: &[u8],
+    proof: Vec<u8>,
+    public_inputs: Vec<u8>,
+) -> Result<bool, Box<dyn Error>> {
+    _verify::<GeminiScheme>(srs_key, verifying_key, proof, public_inputs)
+}
+
 #[cfg(test)]
 mod tests {
-    use fibonacci_circuit::circuit::test_utils::{bad_proof_not_verified_test, helper_functions_test, fibonacci_circuit_test};
+    use fibonacci_circuit::circuit::test_utils::{
+        bad_proof_not_verified_test, fibonacci_circuit_test, helper_functions_test,
+    };
 
     use super::*;
-
 
     #[test]
     fn test_fibonacci_circuit() {

--- a/gemini/tests/integration_test.rs
+++ b/gemini/tests/integration_test.rs
@@ -4,6 +4,7 @@ use gemini_fibonacci::GeminiScheme;
 #[test]
 pub fn gemini_integration_test() {
     test_prove_verify_end_to_end::<GeminiScheme>(
+        "gen-gemini-keys",
         "unihyperplonk-srs-4",
         "out/gemini_fibonacci_pk.bin",
         "out/gemini_fibonacci_vk.bin",

--- a/hyperplonk/Cargo.toml
+++ b/hyperplonk/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "gen-keys"
+name = "gen-hyperplonk-keys"
 path = "src/bin/gen_hyperplonk_keys.rs"
 
 [dependencies]
 fibonacci-circuit = { path = "../circuit" }
 halo2_proofs = { workspace = true }
 plonkish_backend = { workspace = true }
-halo2curves = { workspace = true }

--- a/hyperplonk/tests/integration_test.rs
+++ b/hyperplonk/tests/integration_test.rs
@@ -4,6 +4,7 @@ use hyperplonk_fibonacci::HyperPlonkScheme;
 #[test]
 pub fn hyperplonk_integration_test() {
     test_prove_verify_end_to_end::<HyperPlonkScheme>(
+        "gen-hyperplonk-keys",
         "hyperplonk-srs-4",
         "out/hyperplonk_fibonacci_pk.bin",
         "out/hyperplonk_fibonacci_vk.bin",

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -4,14 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "gen-keys"
+name = "gen-plonk-keys"
 path = "src/bin/gen_plonk_keys.rs"
 
 [dependencies]
 fibonacci-circuit = { path = "../circuit" }
 halo2_proofs = { workspace = true }
 plonkish_backend = { workspace = true }
-halo2curves = { workspace = true }
 serde = { version = "1.0.210", features = ["derive"] }
 bincode = { workspace = true }
 rand = "0.8.5"

--- a/plonk/src/lib.rs
+++ b/plonk/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, error::Error, fs::File};
+#[cfg(not(target_arch = "wasm32"))]
+use std::fs::File;
+#[cfg(target_arch = "wasm32")]
+use std::io::BufReader;
+use std::{collections::HashMap, error::Error};
 
 use fibonacci_circuit::{serialisation::*, FibonacciCircuit, FibonacciError, GenerateProofResult};
 use halo2_proofs::{
@@ -77,6 +81,7 @@ pub fn verify_halo2_proof(
     Ok(result)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn prove(
     srs_key_path: &str,
     proving_key_path: &str,
@@ -113,6 +118,44 @@ pub fn prove(
     Ok((proof, serialized_inputs))
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn prove(
+    srs_key: &[u8],
+    proving_key: &[u8],
+    input: HashMap<String, Vec<String>>,
+) -> Result<GenerateProofResult, Box<dyn Error>> {
+    let mut params_reader = BufReader::new(srs_key);
+    let params =
+        ParamsKZG::<Bn256>::read(&mut params_reader).expect("Failed to read params from bytes");
+
+    let circuit = FibonacciCircuit::<Fr>::default();
+
+    let mut pk_reader = BufReader::new(proving_key);
+    let proving_key =
+        ProvingKey::read::<_, FibonacciCircuit<Fr>, false>(&mut pk_reader, RawBytes).unwrap();
+
+    let circuit_inputs = deserialize_circuit_inputs(input)
+        .map_err(|e| FibonacciError(format!("Failed to deserialize circuit inputs: {}", e)))?;
+
+    let out = circuit_inputs
+        .get("out")
+        .ok_or(FibonacciError("Failed to get `out` value".to_string()))?
+        .get(0)
+        .ok_or(FibonacciError("Failed to get `out` value".to_string()))?
+        .clone();
+
+    // The public input followed fibonacci circuit
+    let public_input = vec![Fr::from(1), Fr::from(1), out];
+
+    let (proof, unserialized_inputs) =
+        generate_halo2_proof(&params, &proving_key, circuit, public_input).unwrap();
+    let serialized_inputs = bincode::serialize(&InputsSerialisationWrapper(unserialized_inputs))
+        .map_err(|e| FibonacciError(format!("Serialisation of Inputs failed: {}", e)))?;
+
+    Ok((proof, serialized_inputs))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub fn verify(
     srs_key_path: &str,
     verifying_key_path: &str,
@@ -127,6 +170,30 @@ pub fn verify(
     let vk_fs = &mut File::open(verifying_key_path).expect("Couldn't load proving key form");
     let verifying_key =
         VerifyingKey::read::<_, FibonacciCircuit<Fr>, false>(vk_fs, RawBytes).unwrap();
+
+    let deserialized_inputs: Vec<Fr> =
+        bincode::deserialize::<InputsSerialisationWrapper>(&public_inputs)
+            .map_err(|e| FibonacciError(e.to_string()))?
+            .0;
+
+    let result = verify_halo2_proof(&params, &verifying_key, proof, deserialized_inputs).unwrap();
+
+    Ok(result)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn verify(
+    srs_key: &[u8],
+    verifying_key: &[u8],
+    proof: Vec<u8>,
+    public_inputs: Vec<u8>,
+) -> Result<bool, Box<dyn Error>> {
+    let mut params_reader = BufReader::new(srs_key);
+    let params = ParamsKZG::<Bn256>::read(&mut params_reader).expect("Failed to read params");
+
+    let mut vk_reader = BufReader::new(verifying_key);
+    let verifying_key =
+        VerifyingKey::read::<_, FibonacciCircuit<Fr>, false>(&mut vk_reader, RawBytes).unwrap();
 
     let deserialized_inputs: Vec<Fr> =
         bincode::deserialize::<InputsSerialisationWrapper>(&public_inputs)

--- a/plonk/tests/integration_test.rs
+++ b/plonk/tests/integration_test.rs
@@ -5,6 +5,7 @@ use plonk_fibonacci::*;
 
 #[test]
 pub fn plonk_integration_test() {
+    let genkey_cmd = "gen-plonk-keys";
     let srs_key_path = "perpetual-powers-of-tau-raw-3";
     let proving_key_path = "out/plonk_fibonacci_pk.bin";
     let verifying_key_path = "out/plonk_fibonacci_vk.bin";
@@ -12,7 +13,7 @@ pub fn plonk_integration_test() {
     let mut input = HashMap::new();
     input.insert("out".to_string(), vec!["55".to_string()]);
 
-    setup_keys(&srs_key_path);
+    setup_keys(genkey_cmd, srs_key_path);
 
     let result = prove(&srs_key_path, &proving_key_path, input).unwrap();
 


### PR DESCRIPTION
This is based on the modified [`plonkish - setup_custom`](https://github.com/sifnoc/plonkish/tree/4f42eeb3ff0666c74168d5b375cd789b46998e1b), which now uses a reader instead of a file name as input for the setup_custom function.

In other words, `setup_custom` is now more flexible, as it can accept any input that implements the Read trait, such as a `BufReader` or a `File`.